### PR TITLE
Add doctest support and improve testing workflow

### DIFF
--- a/{{cookiecutter.name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.name}}/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version-file: 'pyproject.toml'
-    - run: python3 -m pip install .[dev]
+    - run: python3 -m pip install .[test]
     - run: make test
   doctest:
     runs-on: ubuntu-latest

--- a/{{cookiecutter.name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.name}}/.github/workflows/test.yml
@@ -14,3 +14,12 @@ jobs:
         python-version-file: 'pyproject.toml'
     - run: python3 -m pip install .[dev]
     - run: make test
+  doctest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v5
+      with:
+        python-version-file: 'pyproject.toml'
+    - run: python3 -m pip install .[docs]
+    - run: make doctest

--- a/{{cookiecutter.name}}/Makefile
+++ b/{{cookiecutter.name}}/Makefile
@@ -27,7 +27,11 @@ fmt:
 
 .PHONY: test
 test:
-	$(PY) -m unittest discover -s tests -v
+	$(PY) -m pytest tests/ -v
+
+.PHONY: doctest
+doctest:
+	$(MAKE) doctest -C docs/
 
 ################################################################################
 # Distribution Package

--- a/{{cookiecutter.name}}/docs/conf.py
+++ b/{{cookiecutter.name}}/docs/conf.py
@@ -23,6 +23,7 @@ version = release = '{{ cookiecutter.version }}'
 # ones.
 extensions = [
     'sphinx.ext.githubpages',
+    'sphinx.ext.doctest',
     'sphinx_design',
     'sphinx_copybutton',
     'sphinx_last_updated_by_git',

--- a/{{cookiecutter.name}}/tests/test_always_pass.py
+++ b/{{cookiecutter.name}}/tests/test_always_pass.py
@@ -1,0 +1,9 @@
+# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
+# DO NOT EDIT.
+
+import unittest
+
+
+class TestAlwaysPass(unittest.TestCase):
+    def test_dummy(self):
+        self.assertTrue(True)


### PR DESCRIPTION
## Summary

- Add `sphinx.ext.doctest` extension to docs configuration
- Add doctest workflow to GitHub Actions
- Update Makefile to use pytest and add doctest target
- Add always-pass unit test for testing framework validation