### PR TITLE
chore: consolidate template file headers

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,8 @@
 
     "github_owner": "sphinx-notes",
     "github_repo": "{{ cookiecutter.name }}",
+    "generated_file_header": "This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.",
+    "dont_edit_header": "DO NOT EDIT.",
     "pypi_name": "{{ cookiecutter.full_name }}",
     "pypi_owner": "SilverRainZ",
 

--- a/{{cookiecutter.name}}/.github/workflows/lint.yml
+++ b/{{cookiecutter.name}}/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+# {{ cookiecutter.generated_file_header }}
+
 name: Ruff
 on: [ push, pull_request ]
 

--- a/{{cookiecutter.name}}/.github/workflows/pages.yml
+++ b/{{cookiecutter.name}}/.github/workflows/pages.yml
@@ -1,3 +1,5 @@
+# {{ cookiecutter.generated_file_header }}
+
 name: Deploy Sphinx documentation to Pages
 
 # Runs on pushes targeting the default branch

--- a/{{cookiecutter.name}}/.github/workflows/pypi.yml
+++ b/{{cookiecutter.name}}/.github/workflows/pypi.yml
@@ -1,3 +1,5 @@
+# {{ cookiecutter.generated_file_header }}
+
 name: Publish package distributions to PyPI
 
 on:

--- a/{{cookiecutter.name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.name}}/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# {{ cookiecutter.generated_file_header }}
+
 name: Publish Github Release
 
 on:

--- a/{{cookiecutter.name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.name}}/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+# {{ cookiecutter.generated_file_header }}
+
 name: Test
 on:
   push:

--- a/{{cookiecutter.name}}/.gitignore
+++ b/{{cookiecutter.name}}/.gitignore
@@ -1,3 +1,5 @@
+# {{ cookiecutter.generated_file_header }}
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/{{cookiecutter.name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.name}}/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# {{ cookiecutter.generated_file_header }}
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.11

--- a/{{cookiecutter.name}}/MANIFEST.in
+++ b/{{cookiecutter.name}}/MANIFEST.in
@@ -1,5 +1,4 @@
-# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-# You need to consider modifying the TEMPLATE or modifying THIS FILE.
+# {{ cookiecutter.generated_file_header }}
 
 include LICENSE
 include README.rst

--- a/{{cookiecutter.name}}/Makefile
+++ b/{{cookiecutter.name}}/Makefile
@@ -1,5 +1,4 @@
-# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-# You need to consider modifying the TEMPLATE or modifying THIS FILE.
+# {{ cookiecutter.generated_file_header }}
 
 LANG = en_US.UTF-8
 

--- a/{{cookiecutter.name}}/README.rst
+++ b/{{cookiecutter.name}}/README.rst
@@ -1,5 +1,4 @@
-.. This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-   You need to consider modifying the TEMPLATE or modifying THIS FILE.
+.. {{ cookiecutter.generated_file_header }}
 
 {% for _ in cookiecutter.full_name %}={% endfor %}
 {{ cookiecutter.full_name }}

--- a/{{cookiecutter.name}}/docs/Makefile
+++ b/{{cookiecutter.name}}/docs/Makefile
@@ -1,5 +1,4 @@
-# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-# You need to consider modifying the TEMPLATE or modifying THIS FILE.
+# {{ cookiecutter.generated_file_header }}
 
 # Minimal makefile for Sphinx documentation
 

--- a/{{cookiecutter.name}}/docs/_images/.gitkeep
+++ b/{{cookiecutter.name}}/docs/_images/.gitkeep
@@ -1,0 +1,1 @@
+# {{ cookiecutter.generated_file_header }}

--- a/{{cookiecutter.name}}/docs/_static/.gitkeep
+++ b/{{cookiecutter.name}}/docs/_static/.gitkeep
@@ -1,0 +1,1 @@
+# {{ cookiecutter.generated_file_header }}

--- a/{{cookiecutter.name}}/docs/_static/custom.css
+++ b/{{cookiecutter.name}}/docs/_static/custom.css
@@ -1,5 +1,5 @@
-/* This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
- * DO NOT EDIT.
+/* {{ cookiecutter.generated_file_header }}
+ * {{ cookiecutter.dont_edit_header }}
  */
 
 /* Missing style for nodes.system_message from Alabaster. */

--- a/{{cookiecutter.name}}/docs/changelog.rst
+++ b/{{cookiecutter.name}}/docs/changelog.rst
@@ -1,5 +1,4 @@
-.. This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-   You need to consider modifying the TEMPLATE or modifying THIS FILE.
+.. {{ cookiecutter.generated_file_header }}
 
 ==========
 Change Log

--- a/{{cookiecutter.name}}/docs/conf.py
+++ b/{{cookiecutter.name}}/docs/conf.py
@@ -1,5 +1,4 @@
-# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-# You need to consider modifying the TEMPLATE or modifying THIS FILE.
+# {{ cookiecutter.generated_file_header }}
 
 # Configuration file for the Sphinx documentation builder.
 #

--- a/{{cookiecutter.name}}/docs/index.rst
+++ b/{{cookiecutter.name}}/docs/index.rst
@@ -1,5 +1,4 @@
-.. This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-   You need to consider modifying the TEMPLATE or modifying THIS FILE.
+.. {{ cookiecutter.generated_file_header }}
 
 {% for _ in cookiecutter.full_name %}={% endfor %}
 {{ cookiecutter.full_name }}

--- a/{{cookiecutter.name}}/docs/make.bat
+++ b/{{cookiecutter.name}}/docs/make.bat
@@ -1,4 +1,5 @@
-REM This file is generated from {{ cookiecutter.github_owner }}/cookiecutter. DO NOT EDIT.
+REM {{ cookiecutter.generated_file_header }}
+REM {{ cookiecutter.dont_edit_header }}
 
 @ECHO OFF
 

--- a/{{cookiecutter.name}}/pyproject.toml
+++ b/{{cookiecutter.name}}/pyproject.toml
@@ -1,5 +1,4 @@
-# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-# You need to consider modifying the TEMPLATE or modifying THIS FILE.
+# {{ cookiecutter.generated_file_header }}
 
 # This file is used to configure your project.
 # Read more about the various options under:

--- a/{{cookiecutter.name}}/ruff.toml
+++ b/{{cookiecutter.name}}/ruff.toml
@@ -1,5 +1,4 @@
-# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-# You need to consider modifying the TEMPLATE or modifying THIS FILE.
+# {{ cookiecutter.generated_file_header }}
 
 exclude = [
     "docs/conf.py",

--- a/{{cookiecutter.name}}/src/{{cookiecutter.namespace}}/{{cookiecutter.name}}/meta.py
+++ b/{{cookiecutter.name}}/src/{{cookiecutter.namespace}}/{{cookiecutter.name}}/meta.py
@@ -1,5 +1,5 @@
-# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-# DO NOT EDIT!!!
+# {{ cookiecutter.generated_file_header }}
+# {{ cookiecutter.dont_edit_header }}
 
 ################################################################################
 # Project meta infos.

--- a/{{cookiecutter.name}}/tests/__init__.py
+++ b/{{cookiecutter.name}}/tests/__init__.py
@@ -1,0 +1,1 @@
+# {{ cookiecutter.generated_file_header }}

--- a/{{cookiecutter.name}}/tests/test_always_pass.py
+++ b/{{cookiecutter.name}}/tests/test_always_pass.py
@@ -1,5 +1,5 @@
-# This file is generated from {{ cookiecutter.github_owner }}/cookiecutter.
-# DO NOT EDIT.
+# {{ cookiecutter.generated_file_header }}
+# {{ cookiecutter.dont_edit_header }}
 
 import unittest
 


### PR DESCRIPTION
## Summary
- add `generated_file_header` and `dont_edit_header` to `cookiecutter.json` so template file headers are configured in one place
- apply the generated-file header across the template's text files and keep a separate do-not-edit header only on files that previously carried it
- verify the template still renders with `cookiecutter --no-input . --output-dir /tmp/cookiecutter-header-check`