### PR TITLE
chore: move docs deps to requirements

### DIFF
--- a/{{cookiecutter.name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.name}}/.github/workflows/test.yml
@@ -23,5 +23,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version-file: 'pyproject.toml'
-    - run: python3 -m pip install .[docs]
+    - run: python3 -m pip install .
+    - run: python3 -m pip install -r docs/requirements.txt
     - run: make doctest

--- a/{{cookiecutter.name}}/docs/requirements.txt
+++ b/{{cookiecutter.name}}/docs/requirements.txt
@@ -1,3 +1,5 @@
+# {{ cookiecutter.generated_file_header }}
+
 # Documentation build dependencies.
 # Keep these out of pyproject optional-dependencies to avoid resolver issues.
 furo
@@ -12,3 +14,6 @@ sphinxnotes-project
 {%- if cookiecutter.name != 'comboroles' %}
 sphinxnotes-comboroles
 {%- endif %}
+
+# CUSTOM DOCS DEPENDENCIES START
+# CUSTOM DOCS DEPENDENCIES END

--- a/{{cookiecutter.name}}/docs/requirements.txt
+++ b/{{cookiecutter.name}}/docs/requirements.txt
@@ -1,0 +1,14 @@
+# Documentation build dependencies.
+# Keep these out of pyproject optional-dependencies to avoid resolver issues.
+furo
+sphinx_copybutton
+sphinxcontrib-gtagjs
+sphinx-sitemap
+sphinxext-opengraph
+sphinx-last-updated-by-git
+{%- if cookiecutter.name != 'project' %}
+sphinxnotes-project
+{%- endif %}
+{%- if cookiecutter.name != 'comboroles' %}
+sphinxnotes-comboroles
+{%- endif %}

--- a/{{cookiecutter.name}}/pyproject.toml
+++ b/{{cookiecutter.name}}/pyproject.toml
@@ -60,26 +60,6 @@ dev = [
 test = [
     "pytest",
 ]
-docs = [
-    "furo",
-    "sphinx_design",
-    "sphinx_copybutton",
-    "sphinxcontrib-gtagjs",
-    "sphinx-sitemap",
-    "sphinxext-opengraph",
-    "sphinx-last-updated-by-git",
-
-    # Dependencies of sphinxnotes projcts.
-{%- if cookiecutter.name != 'project' %}
-    "sphinxnotes-project",
-{%- endif %}
-{%- if cookiecutter.name != 'comboroles' %}
-    "sphinxnotes-comboroles",
-{%- endif %}
-
-    # CUSTOM DOCS DEPENDENCIES START
-    # CUSTOM DOCS DEPENDENCIES END
-]
 
 [project.urls]
 homepage = "https://sphinx.silverrainz.me/{{ cookiecutter.name }}"


### PR DESCRIPTION
## Summary
- remove the generated docs optional dependency group from package metadata
- install docs dependencies from docs/requirements.txt in the doctest workflow
- keep docs-only bootstrap dependencies out of pyproject.toml to avoid resolver cycles

## Testing
- not run
- verified template diff and git diff --check locally