### PR TITLE
chore: update GitHub Actions versions

### DIFF
--- a/{{cookiecutter.name}}/.github/workflows/lint.yml
+++ b/{{cookiecutter.name}}/.github/workflows/lint.yml
@@ -7,5 +7,5 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: chartboost/ruff-action@v1

--- a/{{cookiecutter.name}}/.github/workflows/pypi.yml
+++ b/{{cookiecutter.name}}/.github/workflows/pypi.yml
@@ -16,8 +16,8 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
     - run: pip install build twine && make dist
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/{{cookiecutter.name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.name}}/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ncipollo/release-action@v1
         with:
           body: |

--- a/{{cookiecutter.name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.name}}/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version-file: 'pyproject.toml'
     - run: python3 -m pip install .[test]
@@ -19,8 +19,8 @@ jobs:
   doctest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version-file: 'pyproject.toml'
     - run: python3 -m pip install .[docs]


### PR DESCRIPTION
## Summary
- update actions/checkout to v6 in generated workflows
- update actions/setup-python to v6 in generated workflows
- keep generated CI compatible with the Node 24 runner migration

## Testing
- not run
- verified workflow references and git diff --check locally